### PR TITLE
Added Ollama Captioning & Run File

### DIFF
--- a/ollama_video_caption_csv.py
+++ b/ollama_video_caption_csv.py
@@ -1,0 +1,174 @@
+import argparse
+import os
+import random
+from typing import Any, Dict
+
+import numpy as np
+import pandas as pd
+import torch
+from decord import VideoReader, cpu
+from transformers import AutoModel, AutoTokenizer
+from PIL import Image
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_ollama.llms import OllamaLLM
+
+def get_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--ollama_model", type=str, required=False, default="llama3.2:3b", help="LLM in Ollama."
+    )
+    parser.add_argument(
+        "--instance_data_root", type=str, required=True, help="Base folder where video files are located."
+    )
+    parser.add_argument("--cache_dir", type=str, default=None, help="Path to where models are stored.")
+    parser.add_argument(
+        "--output_path", type=str, default="video_dataset.csv", help="File path where dataset csv should be stored."
+    )
+    parser.add_argument("--max_new_tokens", type=int, default=226, help="Maximum number of new tokens to generate.")
+    parser.add_argument("--seed", type=int, default=42, help="Seed for reproducibility")
+    return parser.parse_args()
+
+
+SYSTEM_PROMPT = """
+You are part of a team of people that create videos using generative models. You use a video-generation model that can generate a video about anything you describe. You will take inputs and generate a prompt for the video generation model.
+
+For example, if you respond with "A beautiful morning in the woods with the sun peaking through the trees", the video generation model will create a video of exactly as described. You task is to summarize the descriptions of videos provided to by users, and create details prompts to feed into the generative model.
+
+There are rules to follow:
+- Your entire response will be a single line of text.
+- You will not describe what you're doing, you will just respond with the prompt.
+- If the user mentions to summarize the prompt in [X] words, make sure to not exceed the limit.
+
+You responses should just be the video generation prompt. Here is an example:
+```
+A detailed wooden toy ship with intricately carved masts and sails is seen gliding smoothly over a plush, blue carpet that mimics the waves of the sea. The ship's hull is painted a rich brown, with tiny windows. The carpet, soft and textured, provides a perfect backdrop, resembling an oceanic expanse. Surrounding the ship are various other toys and children's items, hinting at a playful environment. The scene captures the innocence and imagination of childhood, with the toy ship's journey symbolizing endless adventures in a whimsical, indoor setting.
+```
+A street artist, clad in a worn-out denim jacket and a colorful bandana, stands before a vast concrete wall in the heart, holding a can of spray paint, spray-painting a colorful bird on a mottled wall
+""".strip()
+
+USER_PROMPT = """
+Generate a prompt for a video generation model for the following video summary:
+
+```
+{0}
+```
+
+Please limit the prompt to [{1}] words.
+""".strip()
+
+QUESTION = """
+Describe the video. You should pay close attention to every detail in the video and describe it in as much detail as possible.
+""".strip()
+
+MAX_NUM_FRAMES = 49
+
+def set_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def encode_video(video_path: str):
+    def uniform_sample(l, n):
+        gap = len(l) / n
+        idxs = [int(i * gap + gap / 2) for i in range(n)]
+        return [l[i] for i in idxs]
+
+    vr = VideoReader(video_path, ctx=cpu(0))
+    sample_fps = round(vr.get_avg_fps())
+    sample_fps //= 2
+    frame_idx = [i for i in range(0, len(vr), sample_fps)]
+    if len(frame_idx) > MAX_NUM_FRAMES:
+        frame_idx = uniform_sample(frame_idx, MAX_NUM_FRAMES)
+    frames = vr.get_batch(frame_idx).asnumpy()
+    frames = [Image.fromarray(v.astype("uint8")) for v in frames]
+    print("num frames:", len(frames))
+    return frames
+
+
+@torch.no_grad()
+def main(args: Dict[str, Any]):
+    # Test that Ollama is functional
+    messages = [
+        HumanMessage(content="Just Testing."),
+    ]
+    model = OllamaLLM(model=args.ollama_model)
+    output = model.invoke(messages)
+    print(output)
+
+    set_seed(args.seed)
+
+    video_files = [file for file in os.listdir(args.instance_data_root) if file.endswith(".mp4")]
+    video_files = [os.path.join(args.instance_data_root, file) for file in video_files]
+    video_descriptions = {}
+
+    model_id = "openbmb/MiniCPM-V-2_6"
+    model = AutoModel.from_pretrained(
+        model_id, trust_remote_code=True, attn_implementation="sdpa", torch_dtype=torch.bfloat16
+    ).to("cuda")
+    tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+
+    for filepath in video_files:
+        print(f"Generating video summary for file: `{filepath}`")
+        frames = encode_video(filepath)
+        msgs = [{"role": "user", "content": frames + [QUESTION]}]
+
+        params = {
+            "use_image_id": False,
+            "max_slice_nums": 1,
+        }
+
+        description = model.chat(image=None, msgs=msgs, tokenizer=tokenizer, **params)
+
+        print(description)
+
+        video_descriptions[filepath] = {"summary": description}
+
+    del model
+    del tokenizer
+    model = None
+    tokenizer = None
+    torch.cuda.empty_cache()
+
+    for filepath in video_files:
+        print(f"Generating captions for file: `{filepath}`")
+
+        for prompt_type, num_words in [("short_prompt", 25), ("prompt", 75), ("verbose_prompt", 125)]:
+            user_prompt = video_descriptions[filepath]["summary"]
+
+            messages = [
+                SystemMessage(content=SYSTEM_PROMPT),
+                HumanMessage(content=user_prompt),
+            ]
+
+            model = OllamaLLM(model=args.ollama_model)
+            output = model.invoke(messages)
+
+            print(output)
+
+            video_descriptions[filepath][prompt_type] = output
+
+    df_data = []
+    for filepath, description in video_descriptions.items():
+        relative_path = os.path.relpath(filepath, args.instance_data_root)
+        df_data.append(
+            {
+                "path": relative_path,
+                "short_prompt": description.get("short_prompt", ""),
+                "prompt": description.get("prompt", ""),
+                "verbose_prompt": description.get("verbose_prompt", ""),
+                "summary": description.get("summary", ""),
+            }
+        )
+
+    df = pd.DataFrame(df_data)
+    df.to_csv(args.output_path)
+
+    print(f"Done. Saved to {args.output_path}")
+
+
+if __name__ == "__main__":
+    args = get_args()
+    main(args)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ torchao>=0.5.0
 sentencepiece>=0.2.0
 imageio-ffmpeg>=0.5.1
 numpy>=1.26.4
+langchain_core
+langchain_ollama

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,6 @@ fi
 
 # Video captioning configuration
 OLLAMA_MODEL="llama3.1:latest"
-# "crown/darkidol:latest"
 DATA_ROOT="./datasets/$ID_TOKEN"
 DATASET_FILE="./datasets/${ID_TOKEN}_output.csv"
 DATA_ROOT_TRAIN="./datasets/${ID_TOKEN}_prepared"
@@ -38,7 +37,7 @@ MAX_NUM_FRAMES="49"
 MAX_SEQUENCE_LENGTH=226
 TARGET_FPS=8
 BATCH_SIZE=1
-DTYPE=fp16
+DTYPE="fp16"
 
 # Training configuration
 GPU_IDS="0"
@@ -108,7 +107,7 @@ train_model() {
             --id_token $ID_TOKEN \
             --seed 42 \
             --rank 128 \
-            --lora_alpha 32 \
+            --lora_alpha 128 \
             --mixed_precision $DTYPE_TRAIN \
             --output_dir $output_dir \
             --height 480 \
@@ -131,8 +130,14 @@ train_model() {
             --enable_slicing \
             --enable_tiling \
             --optimizer $optimizer \
+            --resume_from_checkpoint latest \
+            --noised_image_dropout 0.05 \
+            --beta1 0.9 \
+            --beta2 0.95 \
+            --weight_decay 0.001 \
             --max_grad_norm 1.0 \
-            --resume_from_checkpoint latest"
+            --allow_tf32 \
+            --nccl_timeout 1800"
           
           echo "Running command: $cmd"
           eval $cmd

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+
+# Parse command-line arguments
+while getopts "i:" opt; do
+  case $opt in
+    i) ID_TOKEN="$OPTARG"
+    ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+        exit 1
+    ;;
+  esac
+done
+
+# Check if ID_TOKEN is set
+if [ -z "$ID_TOKEN" ]; then
+  echo "ID_TOKEN is required. Use -i to specify it."
+  exit 1
+fi
+
+# Video captioning configuration
+OLLAMA_MODEL="llama3.1:latest"
+DATA_ROOT="./datasets/$ID_TOKEN"
+DATASET_FILE="./datasets/${ID_TOKEN}_output.csv"
+DATA_ROOT_TRAIN="./datasets/${ID_TOKEN}_prepared"
+
+# Put a folder of videos in ./datasets directory. The name of the folder will be the id token i.e. ohnx
+# Prepare dataset configuration
+MODEL_ID_PRE_ENCODING="THUDM/CogVideoX-2b"
+NUM_GPUS=1
+CAPTION_COLUMN="short_prompt"
+VIDEO_COLUMN="path"
+VIDEO_RESHAPE_MODE="center"
+HEIGHT_BUCKETS="480"
+WIDTH_BUCKETS="720"
+FRAME_BUCKETS="49"
+MAX_NUM_FRAMES="49"
+MAX_SEQUENCE_LENGTH=226
+TARGET_FPS=8
+BATCH_SIZE=1
+DTYPE=fp16
+
+# Training configuration
+GPU_IDS="0"
+LEARNING_RATES=("1e-3")
+LR_SCHEDULES=("cosine_with_restarts")
+OPTIMIZERS=("AdamW")
+MAX_TRAIN_STEPS=("1000")
+ACCELERATE_CONFIG_FILE="accelerate_configs/default_config.yaml"
+MODEL_ID_TRAIN="THUDM/CogVideoX-5b-I2V"
+CAPTION_COLUMN_TRAIN="prompts.txt"
+VIDEO_COLUMN_TRAIN="videos.txt"
+OUTPUT_PATH_TRAIN="./outputs"
+DTYPE_TRAIN="fp16"
+
+# Function to run video captioning
+run_video_captioning() {
+  echo "Running video captioning..."
+  python ollama_video_caption_csv.py --instance_data_root $DATA_ROOT --output_path $DATASET_FILE --ollama_model $OLLAMA_MODEL
+}
+
+# Function to prepare dataset
+prepare_dataset() {
+  echo "Preparing dataset..."
+  CMD_PRE_ENCODING="\
+    torchrun --nproc_per_node=$NUM_GPUS \
+      training/prepare_dataset.py \
+        --model_id $MODEL_ID_PRE_ENCODING \
+        --data_root $DATA_ROOT \
+        --dataset_file $DATASET_FILE \
+        --caption_column $CAPTION_COLUMN \
+        --video_column $VIDEO_COLUMN \
+        --output_dir $DATA_ROOT_TRAIN \
+        --height_buckets $HEIGHT_BUCKETS \
+        --width_buckets $WIDTH_BUCKETS \
+        --frame_buckets $FRAME_BUCKETS \
+        --max_num_frames $MAX_NUM_FRAMES \
+        --max_sequence_length $MAX_SEQUENCE_LENGTH \
+        --target_fps $TARGET_FPS \
+        --batch_size $BATCH_SIZE \
+        --dtype $DTYPE \
+        --video_reshape_mode $VIDEO_RESHAPE_MODE \
+        --save_latents_and_embeddings \
+        --save_image_latents \
+        --use_tiling
+  "
+  echo "===== Running \`$CMD_PRE_ENCODING\` ====="
+  eval $CMD_PRE_ENCODING
+  echo -ne "===== Finished running script =====\n"
+}
+
+# Function to train the model
+train_model() {
+  echo "Training model..."
+  for learning_rate in "${LEARNING_RATES[@]}"; do
+    for lr_schedule in "${LR_SCHEDULES[@]}"; do
+      for optimizer in "${OPTIMIZERS[@]}"; do
+        for steps in "${MAX_TRAIN_STEPS[@]}"; do
+          output_dir="${OUTPUT_PATH_TRAIN}/$ID_TOKEN/cogvideox-lora__optimizer_${optimizer}__steps_${steps}__lr-schedule_${lr_schedule}__learning-rate_${learning_rate}/"
+
+          # We don't do validation because we can't fit in GPU VRAM
+          cmd="accelerate launch --config_file $ACCELERATE_CONFIG_FILE --gpu_ids $GPU_IDS training/cogvideox_image_to_video_lora.py \
+            --pretrained_model_name_or_path $MODEL_ID_TRAIN \
+            --load_tensors \
+            --data_root $DATA_ROOT_TRAIN \
+            --caption_column $CAPTION_COLUMN_TRAIN \
+            --video_column $VIDEO_COLUMN_TRAIN \
+            --gradient_checkpointing \
+            --enable_tiling \
+            --enable_slicing \
+            --id_token $ID_TOKEN, \
+            --seed 42 \
+            --rank 128 \
+            --lora_alpha 32 \
+            --mixed_precision $DTYPE_TRAIN \
+            --output_dir $output_dir \
+            --height 480 \
+            --width 720 \
+            --fps 8 \
+            --max_num_frames 49 \
+            --skip_frames_start 0 \
+            --skip_frames_end 0 \
+            --train_batch_size 1 \
+            --num_train_epochs 150 \
+            --checkpointing_steps 1000 \
+            --gradient_accumulation_steps 1 \
+            --max_train_steps $steps \
+            --checkpointing_steps 1000 \
+            --gradient_accumulation_steps 1 \
+            --gradient_checkpointing \
+            --learning_rate $learning_rate \
+            --lr_scheduler $lr_schedule \
+            --lr_warmup_steps 200 \
+            --lr_num_cycles 1 \
+            --enable_slicing \
+            --enable_tiling \
+            --gradient_checkpointing \
+            --optimizer $optimizer \
+            --max_grad_norm 1.0 \
+            --resume_from_checkpoint latest"
+          
+          echo "Running command: $cmd"
+          eval $cmd
+          echo -ne "-------------------- Finished executing script --------------------\n\n"
+        done
+      done
+    done
+  done
+}
+
+# Execute the functions
+
+# Check for dataset folder
+if [ ! -d "$DATA_ROOT" ]; then
+  echo "Dataset folder not found ($DATA_ROOT). Exiting."
+  exit 1
+fi
+
+echo "Dataset folder found ($DATA_ROOT). Continuing."
+
+# Check if the captions are already generated, if not, generate them
+if [ ! -f "$DATASET_FILE" ]; then
+  echo "Captions not found ($DATASET_FILE). Generating."
+  run_video_captioning
+fi
+
+echo "Captions found ($DATASET_FILE). Continuing."
+
+# Check if the dataset is prepared, if not, prepare it
+if [ ! -d "$DATA_ROOT_TRAIN" ]; then
+  echo "Dataset not prepared ($DATA_ROOT_TRAIN). Preparing."
+  prepare_dataset
+fi
+
+# Train the model
+echo "Dataset prepared ($DATA_ROOT_TRAIN). Training."
+train_model
+
+echo "All tasks completed."

--- a/run.sh
+++ b/run.sh
@@ -19,6 +19,7 @@ fi
 
 # Video captioning configuration
 OLLAMA_MODEL="llama3.1:latest"
+# "crown/darkidol:latest"
 DATA_ROOT="./datasets/$ID_TOKEN"
 DATASET_FILE="./datasets/${ID_TOKEN}_output.csv"
 DATA_ROOT_TRAIN="./datasets/${ID_TOKEN}_prepared"
@@ -104,10 +105,7 @@ train_model() {
             --data_root $DATA_ROOT_TRAIN \
             --caption_column $CAPTION_COLUMN_TRAIN \
             --video_column $VIDEO_COLUMN_TRAIN \
-            --gradient_checkpointing \
-            --enable_tiling \
-            --enable_slicing \
-            --id_token $ID_TOKEN, \
+            --id_token $ID_TOKEN \
             --seed 42 \
             --rank 128 \
             --lora_alpha 32 \
@@ -125,7 +123,6 @@ train_model() {
             --gradient_accumulation_steps 1 \
             --max_train_steps $steps \
             --checkpointing_steps 1000 \
-            --gradient_accumulation_steps 1 \
             --gradient_checkpointing \
             --learning_rate $learning_rate \
             --lr_scheduler $lr_schedule \
@@ -133,7 +130,6 @@ train_model() {
             --lr_num_cycles 1 \
             --enable_slicing \
             --enable_tiling \
-            --gradient_checkpointing \
             --optimizer $optimizer \
             --max_grad_norm 1.0 \
             --resume_from_checkpoint latest"


### PR DESCRIPTION
After hours of testing and iterating, I've finally created a fool-proof LoRA training workflow for cog using cogvideox-factory on 24gb Nvidia video cards.

**Goal:** Take a folder of videos and create a LoRA.

It does use Ollama to convert the video descriptions to captions. You can modify this pretty easily if you want. I like using Ollama because you can easily swap and test other models for better captioning.

This works in WSL.

```
git clone https://github.com/a-r-r-o-w/cogvideox-factory
cd cogvideox-factory
```

- Place your videos in `./cogvideox-factory/datasets/ohnx`

```
python -m venv venv
source venv/bin/activate
pip install -r requirements.txt
sudo chmod +x run.sh
./run.sh -i ohnx
```

This will generate your captions, prepare your dataset, and run training in a single script file. Open run.sh to view the settings. 

Notes:
-  `ohnx` becomes your id token for your LoRA.
- Params are experimental. Steps is at 1000, this takes 2.5 hours approximately on a 4090.