### PR TITLE
Precomputation folder name based on model name

### DIFF
--- a/finetrainers/trainer.py
+++ b/finetrainers/trainer.py
@@ -217,7 +217,11 @@ class Trainer:
                     batched_text_conditions[key] = [x[key] for x in text_conditions][0]
             return {"latent_conditions": batched_latent_conditions, "text_conditions": batched_text_conditions}
 
-        should_precompute = should_perform_precomputation(self.args.data_root, self.args.model_name)
+        cleaned_model_id = string_to_filename(self.args.pretrained_model_name_or_path)
+        precomputation_dir = (
+            Path(self.args.data_root) / f"{self.args.model_name}_{cleaned_model_id}_{PRECOMPUTED_DIR_NAME}"
+        )
+        should_precompute = should_perform_precomputation(precomputation_dir)
         if not should_precompute:
             logger.info("Precomputed conditions and latents found. Loading precomputed data.")
             self.dataloader = torch.utils.data.DataLoader(
@@ -252,14 +256,8 @@ class Trainer:
                 "Caption dropout is not supported with precomputation yet. This will be supported in the future."
             )
 
-        conditions_dir = (
-            Path(self.args.data_root)
-            / f"{self.args.model_name}_{PRECOMPUTED_DIR_NAME}"
-            / PRECOMPUTED_CONDITIONS_DIR_NAME
-        )
-        latents_dir = (
-            Path(self.args.data_root) / f"{self.args.model_name}_{PRECOMPUTED_DIR_NAME}" / PRECOMPUTED_LATENTS_DIR_NAME
-        )
+        conditions_dir = precomputation_dir / PRECOMPUTED_CONDITIONS_DIR_NAME
+        latents_dir = precomputation_dir / PRECOMPUTED_LATENTS_DIR_NAME
         conditions_dir.mkdir(parents=True, exist_ok=True)
         latents_dir.mkdir(parents=True, exist_ok=True)
 

--- a/finetrainers/utils/data_utils.py
+++ b/finetrainers/utils/data_utils.py
@@ -3,17 +3,17 @@ from typing import Union
 
 from accelerate.logging import get_logger
 
-from ..constants import PRECOMPUTED_CONDITIONS_DIR_NAME, PRECOMPUTED_DIR_NAME, PRECOMPUTED_LATENTS_DIR_NAME
+from ..constants import PRECOMPUTED_CONDITIONS_DIR_NAME, PRECOMPUTED_LATENTS_DIR_NAME
 
 
 logger = get_logger("finetrainers")
 
 
-def should_perform_precomputation(data_root: Union[str, Path], model_name: str) -> bool:
-    if isinstance(data_root, str):
-        data_root = Path(data_root)
-    conditions_dir = data_root / f"{model_name}_{PRECOMPUTED_DIR_NAME}" / PRECOMPUTED_CONDITIONS_DIR_NAME
-    latents_dir = data_root / f"{model_name}_{PRECOMPUTED_DIR_NAME}" / PRECOMPUTED_LATENTS_DIR_NAME
+def should_perform_precomputation(precomputation_dir: Union[str, Path]) -> bool:
+    if isinstance(precomputation_dir, str):
+        precomputation_dir = Path(precomputation_dir)
+    conditions_dir = precomputation_dir / PRECOMPUTED_CONDITIONS_DIR_NAME
+    latents_dir = precomputation_dir / PRECOMPUTED_LATENTS_DIR_NAME
     if conditions_dir.exists() and latents_dir.exists():
         num_files_conditions = len(list(conditions_dir.glob("*.pt")))
         num_files_latents = len(list(latents_dir.glob("*.pt")))


### PR DESCRIPTION
Currently, if we try to train two models with same datasets and enabling precomputation, it is not possible. This PR adds model_name to the folder so that the name clash does not happen

Tested on smol run for LTX:

<details>
<summary> Script </summary>

```bash
#!/bin/bash

# export TORCH_LOGS="+dynamo,recompiles,graph_breaks"
# export TORCHDYNAMO_VERBOSE=1
export WANDB_MODE="disabled"
export NCCL_P2P_DISABLE=1
export TORCH_NCCL_ENABLE_MONITORING=0

GPU_IDS="2"

DATA_ROOT="/raid/aryan/video-dataset-disney"
CAPTION_COLUMN="prompts2.txt"
VIDEO_COLUMN="videos2.txt"

# Model arguments
model_cmd="--model_name ltx_video \
  --pretrained_model_name_or_path a-r-r-o-w/LTX-Video-diffusers"

# Dataset arguments
dataset_cmd="--data_root $DATA_ROOT \
  --video_column $VIDEO_COLUMN \
  --caption_column $CAPTION_COLUMN \
  --id_token afkx \
  --video_resolution_buckets 49x512x768 \
  --caption_dropout_p 0.00 \
  --precompute_conditions"

# Dataloader arguments
dataloader_cmd="--dataloader_num_workers 0"

# Diffusion arguments
diffusion_cmd="--flow_weighting_scheme logit_normal"

# Training arguments
training_cmd="--training_type lora \
  --mixed_precision bf16 \
  --seed 42 \
  --batch_size 1 \
  --train_steps 10 \
  --rank 128 \
  --lora_alpha 128 \
  --target_modules to_q to_k to_v to_out.0 \
  --gradient_accumulation_steps 1 \
  --gradient_checkpointing \
  --checkpointing_steps 500 \
  --checkpointing_limit 2 \
  --enable_slicing \
  --enable_tiling"

# Optimizer arguments
optimizer_cmd="--optimizer adamw \
  --lr 1e-4 \
  --lr_scheduler cosine_with_restarts \
  --lr_warmup_steps 100 \
  --lr_num_cycles 1 \
  --beta1 0.9 \
  --beta2 0.95 \
  --weight_decay 1e-4 \
  --epsilon 1e-8 \
  --max_grad_norm 1.0"

# Validation arguments
validation_cmd="--validation_prompts \"afkx A black and white animated scene unfolds with an anthropomorphic goat surrounded by musical notes and symbols, suggesting a playful environment. Mickey Mouse appears, leaning forward in curiosity as the goat remains still. The goat then engages with Mickey, who bends down to converse or react. The dynamics shift as Mickey grabs the goat, potentially in surprise or playfulness, amidst a minimalistic background. The scene captures the evolving relationship between the two characters in a whimsical, animated setting, emphasizing their interactions and emotions.@@@49x480x768:::A woman with long brown hair and light skin smiles at another woman with long blonde hair. The woman with brown hair wears a black jacket and has a small, barely noticeable mole on her right cheek. The camera angle is a close-up, focused on the woman with brown hair's face. The lighting is warm and natural, likely from the setting sun, casting a soft glow on the scene. The scene appears to be real-life footage@@@49x480x768\" \
  --num_validation_videos 1 \
  --validation_steps 5"

# Miscellaneous arguments
miscellaneous_cmd="--tracker_name finetrainers-ltxv \
  --output_dir /raid/aryan/ltx-video \
  --nccl_timeout 1800 \
  --report_to wandb"

cmd="accelerate launch --config_file accelerate_configs/uncompiled_1.yaml --gpu_ids $GPU_IDS train.py \
  $model_cmd \
  $dataset_cmd \
  $dataloader_cmd \
  $diffusion_cmd \
  $training_cmd \
  $optimizer_cmd \
  $validation_cmd \
  $miscellaneous_cmd"

echo "Running command: $cmd"
eval $cmd
echo -ne "-------------------- Finished executing script --------------------\n\n"
```
</details>