### PR TITLE
Fix Wan2.1 I2V fine-tuning

### DIFF
--- a/finetrainers/models/wan/base_specification.py
+++ b/finetrainers/models/wan/base_specification.py
@@ -237,7 +237,7 @@ class WanModelSpecification(ModelSpecification):
             cache_dir=cache_dir,
         )
 
-        use_last_frame = self.transformer_config.pos_embed_seq_len is not None
+        use_last_frame = self.transformer_config.get("pos_embed_seq_len") is not None
 
         if condition_model_processors is None:
             condition_model_processors = [T5Processor(["encoder_hidden_states", "__drop__"])]
@@ -521,7 +521,7 @@ class WanModelSpecification(ModelSpecification):
                 raise ValueError("Either image or video must be provided for Wan I2V validation.")
             image = image if image is not None else video[0]
             generation_kwargs["image"] = image
-        if self.transformer_config.pos_embed_seq_len is not None:
+        if self.transformer_config.get("pos_embed_seq_len") is not None:
             last_image = last_image if last_image is not None else image if video is None else video[-1]
             generation_kwargs["last_image"] = last_image
         generation_kwargs = get_non_null_items(generation_kwargs)


### PR DESCRIPTION
I tried to fine-tune Wan2.1 I2V as it is shown in the `examples/training/sft/wan_i2v/3dgs_dissolve/train.sh`. I downloaded datasets, etc, it was okay.

The issue I've faced was related to the [finetrainers/models/wan/base_specification.py](https://github.com/a-r-r-o-w/finetrainers/blob/main/finetrainers/models/wan/base_specification.py#L240).
It basically said that `self.transformer_config.pos_embed_seq_len` doesn't exist.
When I changed this to `self.transformer_config.get('pos_embed_seq_len')`, the issue was resolved.

FYI:
diffusers version is 0.34.dev (86294d3c7ffa5e97b9483d82c14021d06b701a12)
torch1.7.0+cu128
NVIDIA H100 PCIe

This PR addresses this problem and solves it.